### PR TITLE
Array element access

### DIFF
--- a/FortranAst/src/pt/up/fe/specs/fortran/ast/nodes/expr/ArraySubscriptExpr.java
+++ b/FortranAst/src/pt/up/fe/specs/fortran/ast/nodes/expr/ArraySubscriptExpr.java
@@ -23,7 +23,6 @@ public class ArraySubscriptExpr extends DataRef {
 
     @Override
     public String getCode() {
-
         return getRef().getCode() + "(" +
                 getSubscripts().stream()
                         .map(Expr::getCode)

--- a/FortranAst/src/pt/up/fe/specs/fortran/ast/nodes/expr/ArraySubscriptExpr.java
+++ b/FortranAst/src/pt/up/fe/specs/fortran/ast/nodes/expr/ArraySubscriptExpr.java
@@ -5,8 +5,9 @@ import pt.up.fe.specs.fortran.ast.nodes.FortranNode;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public class ArraySubscriptExpr extends FortranNode {
+public class ArraySubscriptExpr extends DataRef {
 
     public ArraySubscriptExpr(DataStore data, Collection<? extends FortranNode> children) {
         super(data, children);
@@ -18,5 +19,15 @@ public class ArraySubscriptExpr extends FortranNode {
 
     public List<Expr> getSubscripts() {
         return getChildren(Expr.class, 1);
+    }
+
+    @Override
+    public String getCode() {
+
+        return getRef().getCode() + "(" +
+                getSubscripts().stream()
+                        .map(Expr::getCode)
+                        .collect(Collectors.joining(", ")) +
+                ")";
     }
 }

--- a/FortranAst/src/pt/up/fe/specs/fortran/ast/nodes/expr/ArraySubscriptExpr.java
+++ b/FortranAst/src/pt/up/fe/specs/fortran/ast/nodes/expr/ArraySubscriptExpr.java
@@ -1,0 +1,22 @@
+package pt.up.fe.specs.fortran.ast.nodes.expr;
+
+import org.suikasoft.jOptions.Interfaces.DataStore;
+import pt.up.fe.specs.fortran.ast.nodes.FortranNode;
+
+import java.util.Collection;
+import java.util.List;
+
+public class ArraySubscriptExpr extends FortranNode {
+
+    public ArraySubscriptExpr(DataStore data, Collection<? extends FortranNode> children) {
+        super(data, children);
+    }
+
+    public DataRef getRef() {
+        return getChild(DataRef.class);
+    }
+
+    public List<Expr> getSubscripts() {
+        return getChildren(Expr.class, 1);
+    }
+}

--- a/FortranParser/resources-test/fortran/parser/arrays/element_access.expected.f90
+++ b/FortranParser/resources-test/fortran/parser/arrays/element_access.expected.f90
@@ -1,0 +1,9 @@
+PROGRAM array_demonstration
+
+    integer :: vec(5) = [10, 20, 30, 40, 50]
+    integer :: matrix(3,3)
+
+    PRINT *, "The second element is:", vec(2)
+    PRINT *, "Multi dimensional:", matrix(1, 2)
+
+END PROGRAM array_demonstration

--- a/FortranParser/resources-test/fortran/parser/arrays/element_access.f90
+++ b/FortranParser/resources-test/fortran/parser/arrays/element_access.f90
@@ -1,0 +1,9 @@
+program array_demonstration
+
+    integer :: vec(5) = [10, 20, 30, 40, 50]
+    integer :: matrix(3, 3)
+
+    print *, "The second element is:", vec(2)
+    print *, "Multi dimensional:", matrix(1, 2)
+
+end program array_demonstration

--- a/FortranParser/resources-test/fortran/parser/arrays/element_access.json
+++ b/FortranParser/resources-test/fortran/parser/arrays/element_access.json
@@ -1,0 +1,571 @@
+{"nodes": [
+  {
+    "id": "0x61a837e20400-Program",
+    "ProgramUnit": [
+      "0x61a837e50990-ProgramUnit"]
+  },
+  {
+    "id": "0x61a837e50990-ProgramUnit",
+    "value": "0x61a837e4dba0-MainProgram"
+  },
+  {
+    "id": "0x61a837e4dba0-MainProgram",
+    "Statement<ProgramStmt>": "0x61a837e4dce8-Statement",
+    "SpecificationPart": "0x61a837e4dc40-SpecificationPart",
+    "ExecutionPart": "0x61a837e4dc28-ExecutionPart",
+    "Statement<EndProgramStmt>": "0x61a837e4dba0-Statement"
+  },
+  {
+    "id": "0x61a837e4dce8-Statement",
+    "statement": "0x61a837e4dcf8-ProgramStmt",
+    "label": "null",
+    "source": "program array_demonstration"
+  },
+  {
+    "id": "0x61a837e4dcf8-ProgramStmt",
+    "Name": "0x61a837e4dcf8-Name"
+  },
+  {
+    "id": "0x61a837e4dcf8-Name",
+    "source": "array_demonstration"
+  },
+  {
+    "id": "0x61a837e4dc40-SpecificationPart",
+    "ImplicitPart": "0x61a837e4dc58-ImplicitPart",
+    "DeclarationConstruct": [
+      "0x61a837e4c020-DeclarationConstruct",
+      "0x61a837e4b090-DeclarationConstruct"]
+  },
+  {
+    "id": "0x61a837e4dc58-ImplicitPart"
+  },
+  {
+    "id": "0x61a837e4c020-DeclarationConstruct",
+    "value": "0x61a837e4c020-SpecificationConstruct"
+  },
+  {
+    "id": "0x61a837e4c020-SpecificationConstruct",
+    "value<TypeDeclarationStmt>": "0x61a837e4c020-Statement"
+  },
+  {
+    "id": "0x61a837e4c020-Statement",
+    "statement": "0x61a837e2e910-TypeDeclarationStmt",
+    "label": "null",
+    "source": "integer :: vec(5) = [10, 20, 30, 40, 50]"
+  },
+  {
+    "id": "0x61a837e2e910-TypeDeclarationStmt",
+    "DeclarationTypeSpec": "0x61a837e2e940-DeclarationTypeSpec",
+    "EntityDecl": [
+      "0x61a837e4be50-EntityDecl"]
+  },
+  {
+    "id": "0x61a837e2e940-DeclarationTypeSpec",
+    "value": "0x61a837e2e940-IntrinsicTypeSpec"
+  },
+  {
+    "id": "0x61a837e2e940-IntrinsicTypeSpec",
+    "value": "0x61a837e2e940-IntegerTypeSpec"
+  },
+  {
+    "id": "0x61a837e2e940-IntegerTypeSpec"
+  },
+  {
+    "id": "0x61a837e4be50-EntityDecl",
+    "Name": "0x61a837e4bf08-Name",
+    "ArraySpec": "0x61a837e4bed0-ArraySpec",
+    "Initialization": "0x61a837e4be50-Initialization"
+  },
+  {
+    "id": "0x61a837e4bf08-Name",
+    "source": "vec"
+  },
+  {
+    "id": "0x61a837e4bed0-ArraySpec",
+    "value": [
+      "0x61a837e4a580-ExplicitShapeSpec"]
+  },
+  {
+    "id": "0x61a837e4a580-ExplicitShapeSpec",
+    "upper_bound": "0x61a837e4a580-SpecificationExpr"
+  },
+  {
+    "id": "0x61a837e4a580-SpecificationExpr",
+    "Expr": "0x61a837e4a830-Expr"
+  },
+  {
+    "id": "0x61a837e4a830-Expr",
+    "value": "0x61a837e4a850-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4a850-LiteralConstant",
+    "value": "0x61a837e4a850-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4a850-IntLiteralConstant",
+    "CharBlock": "5"
+  },
+  {
+    "id": "0x61a837e4be50-Initialization",
+    "value": "0x61a837e4bd60-Expr"
+  },
+  {
+    "id": "0x61a837e4bd60-Expr",
+    "value": "0x61a837e4bd80-ArrayConstructor"
+  },
+  {
+    "id": "0x61a837e4bd80-ArrayConstructor",
+    "AcSpec": "0x61a837e4bd80-AcSpec"
+  },
+  {
+    "id": "0x61a837e4bd80-AcSpec",
+    "values": [
+      "0x61a837e49840-AcValue",
+      "0x61a837e48e00-AcValue",
+      "0x61a837e48e90-AcValue",
+      "0x61a837e49750-AcValue",
+      "0x61a837e49800-AcValue"]
+  },
+  {
+    "id": "0x61a837e49840-AcValue",
+    "value": "0x61a837e4afa0-Expr"
+  },
+  {
+    "id": "0x61a837e4afa0-Expr",
+    "value": "0x61a837e4afc0-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4afc0-LiteralConstant",
+    "value": "0x61a837e4afc0-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4afc0-IntLiteralConstant",
+    "CharBlock": "10"
+  },
+  {
+    "id": "0x61a837e48e00-AcValue",
+    "value": "0x61a837e4b2a0-Expr"
+  },
+  {
+    "id": "0x61a837e4b2a0-Expr",
+    "value": "0x61a837e4b2c0-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4b2c0-LiteralConstant",
+    "value": "0x61a837e4b2c0-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4b2c0-IntLiteralConstant",
+    "CharBlock": "20"
+  },
+  {
+    "id": "0x61a837e48e90-AcValue",
+    "value": "0x61a837e4b5a0-Expr"
+  },
+  {
+    "id": "0x61a837e4b5a0-Expr",
+    "value": "0x61a837e4b5c0-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4b5c0-LiteralConstant",
+    "value": "0x61a837e4b5c0-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4b5c0-IntLiteralConstant",
+    "CharBlock": "30"
+  },
+  {
+    "id": "0x61a837e49750-AcValue",
+    "value": "0x61a837e4b8a0-Expr"
+  },
+  {
+    "id": "0x61a837e4b8a0-Expr",
+    "value": "0x61a837e4b8c0-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4b8c0-LiteralConstant",
+    "value": "0x61a837e4b8c0-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4b8c0-IntLiteralConstant",
+    "CharBlock": "40"
+  },
+  {
+    "id": "0x61a837e49800-AcValue",
+    "value": "0x61a837e4bba0-Expr"
+  },
+  {
+    "id": "0x61a837e4bba0-Expr",
+    "value": "0x61a837e4bbc0-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4bbc0-LiteralConstant",
+    "value": "0x61a837e4bbc0-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4bbc0-IntLiteralConstant",
+    "CharBlock": "50"
+  },
+  {
+    "id": "0x61a837e4b090-DeclarationConstruct",
+    "value": "0x61a837e4b090-SpecificationConstruct"
+  },
+  {
+    "id": "0x61a837e4b090-SpecificationConstruct",
+    "value<TypeDeclarationStmt>": "0x61a837e4b090-Statement"
+  },
+  {
+    "id": "0x61a837e4b090-Statement",
+    "statement": "0x61a837dfa0f0-TypeDeclarationStmt",
+    "label": "null",
+    "source": "integer :: matrix(3, 3)"
+  },
+  {
+    "id": "0x61a837dfa0f0-TypeDeclarationStmt",
+    "DeclarationTypeSpec": "0x61a837dfa120-DeclarationTypeSpec",
+    "EntityDecl": [
+      "0x61a837e4c240-EntityDecl"]
+  },
+  {
+    "id": "0x61a837dfa120-DeclarationTypeSpec",
+    "value": "0x61a837dfa120-IntrinsicTypeSpec"
+  },
+  {
+    "id": "0x61a837dfa120-IntrinsicTypeSpec",
+    "value": "0x61a837dfa120-IntegerTypeSpec"
+  },
+  {
+    "id": "0x61a837dfa120-IntegerTypeSpec"
+  },
+  {
+    "id": "0x61a837e4c240-EntityDecl",
+    "Name": "0x61a837e4c2f8-Name",
+    "ArraySpec": "0x61a837e4c2c0-ArraySpec"
+  },
+  {
+    "id": "0x61a837e4c2f8-Name",
+    "source": "matrix"
+  },
+  {
+    "id": "0x61a837e4c2c0-ArraySpec",
+    "value": [
+      "0x61a837e48d50-ExplicitShapeSpec",
+      "0x61a837e48d20-ExplicitShapeSpec"]
+  },
+  {
+    "id": "0x61a837e48d50-ExplicitShapeSpec",
+    "upper_bound": "0x61a837e48d50-SpecificationExpr"
+  },
+  {
+    "id": "0x61a837e48d50-SpecificationExpr",
+    "Expr": "0x61a837e4c070-Expr"
+  },
+  {
+    "id": "0x61a837e4c070-Expr",
+    "value": "0x61a837e4c090-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4c090-LiteralConstant",
+    "value": "0x61a837e4c090-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4c090-IntLiteralConstant",
+    "CharBlock": "3"
+  },
+  {
+    "id": "0x61a837e48d20-ExplicitShapeSpec",
+    "upper_bound": "0x61a837e48d20-SpecificationExpr"
+  },
+  {
+    "id": "0x61a837e48d20-SpecificationExpr",
+    "Expr": "0x61a837e4c150-Expr"
+  },
+  {
+    "id": "0x61a837e4c150-Expr",
+    "value": "0x61a837e4c170-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4c170-LiteralConstant",
+    "value": "0x61a837e4c170-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4c170-IntLiteralConstant",
+    "CharBlock": "3"
+  },
+  {
+    "id": "0x61a837e4dc28-ExecutionPart",
+    "ExecutionPartConstruct": [
+      "0x61a837e4a7e0-ExecutionPartConstruct",
+      "0x61a837e4dac0-ExecutionPartConstruct"]
+  },
+  {
+    "id": "0x61a837e4dc28-ExecutionPartConstruct"
+  },
+  {
+    "id": "0x61a837e4a7e0-ExecutionPartConstruct",
+    "value": "0x61a837e4a7e0-ExecutableConstruct"
+  },
+  {
+    "id": "0x61a837e4a7e0-ExecutableConstruct",
+    "value<ActionStmt>": "0x61a837e4a7e0-Statement"
+  },
+  {
+    "id": "0x61a837e4a7e0-Statement",
+    "statement": "0x61a837e4a7f0-ActionStmt",
+    "label": "null",
+    "source": "print *, \"The second element is:\", vec(2)"
+  },
+  {
+    "id": "0x61a837e4a7f0-ActionStmt",
+    "value": "0x61a837e4d060-PrintStmt"
+  },
+  {
+    "id": "0x61a837e4d060-PrintStmt",
+    "Format": "0x61a837e4d078-Format",
+    "OutputItem": [
+      "0x61a837e4c760-OutputItem",
+      "0x61a837e4c670-OutputItem"]
+  },
+  {
+    "id": "0x61a837e4d078-Format",
+    "value": "0x61a837e4d078-Star"
+  },
+  {
+    "id": "0x61a837e4d078-Star"
+  },
+  {
+    "id": "0x61a837e4c760-OutputItem",
+    "value": "0x61a837e4c760-Expr"
+  },
+  {
+    "id": "0x61a837e4c760-Expr",
+    "value": "0x61a837e4c780-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4c780-LiteralConstant",
+    "value": "0x61a837e4c780-CharLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4c780-CharLiteralConstant",
+    "string": "The second element is:"
+  },
+  {
+    "id": "0x61a837e4c670-OutputItem",
+    "value": "0x61a837e4c670-Expr"
+  },
+  {
+    "id": "0x61a837e4c670-Expr",
+    "value": "0x61a837e61750-Designator"
+  },
+  {
+    "id": "0x61a837e61750-Designator",
+    "value": "0x61a837e61760-DataRef"
+  },
+  {
+    "id": "0x61a837e61760-DataRef",
+    "value": "0x61a837ee19b0-ArrayElement"
+  },
+  {
+    "id": "0x61a837ee19b0-ArrayElement",
+    "base": "0x61a837ee19b0-DataRef",
+    "subscripts": [
+      "0x61a837e48db0-SectionSubscript"]
+  },
+  {
+    "id": "0x61a837ee19b0-DataRef",
+    "value": "0x61a837ee19b0-Name"
+  },
+  {
+    "id": "0x61a837ee19b0-Name",
+    "source": "vec"
+  },
+  {
+    "id": "0x61a837e48db0-SectionSubscript",
+    "value": "0x61a837e4e3b0-Expr"
+  },
+  {
+    "id": "0x61a837e4e3b0-Expr",
+    "value": "0x61a837e4e3d0-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4e3d0-LiteralConstant",
+    "value": "0x61a837e4e3d0-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4e3d0-IntLiteralConstant",
+    "CharBlock": "2"
+  },
+  {
+    "id": "0x61a837e4dac0-ExecutionPartConstruct",
+    "value": "0x61a837e4dac0-ExecutableConstruct"
+  },
+  {
+    "id": "0x61a837e4dac0-ExecutableConstruct",
+    "value<ActionStmt>": "0x61a837e4dac0-Statement"
+  },
+  {
+    "id": "0x61a837e4dac0-Statement",
+    "statement": "0x61a837e4dad0-ActionStmt",
+    "label": "null",
+    "source": "print *, \"Multi dimensional:\", matrix(1, 2)"
+  },
+  {
+    "id": "0x61a837e4dad0-ActionStmt",
+    "value": "0x61a837e4d940-PrintStmt"
+  },
+  {
+    "id": "0x61a837e4d940-PrintStmt",
+    "Format": "0x61a837e4d958-Format",
+    "OutputItem": [
+      "0x61a837e4d7f0-OutputItem",
+      "0x61a837e4d700-OutputItem"]
+  },
+  {
+    "id": "0x61a837e4d958-Format",
+    "value": "0x61a837e4d958-Star"
+  },
+  {
+    "id": "0x61a837e4d958-Star"
+  },
+  {
+    "id": "0x61a837e4d7f0-OutputItem",
+    "value": "0x61a837e4d7f0-Expr"
+  },
+  {
+    "id": "0x61a837e4d7f0-Expr",
+    "value": "0x61a837e4d810-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4d810-LiteralConstant",
+    "value": "0x61a837e4d810-CharLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4d810-CharLiteralConstant",
+    "string": "Multi dimensional:"
+  },
+  {
+    "id": "0x61a837e4d700-OutputItem",
+    "value": "0x61a837e4d700-Expr"
+  },
+  {
+    "id": "0x61a837e4d700-Expr",
+    "value": "0x61a837e52ed0-Designator"
+  },
+  {
+    "id": "0x61a837e52ed0-Designator",
+    "value": "0x61a837e52ee0-DataRef"
+  },
+  {
+    "id": "0x61a837e52ee0-DataRef",
+    "value": "0x61a837ee3250-ArrayElement"
+  },
+  {
+    "id": "0x61a837ee3250-ArrayElement",
+    "base": "0x61a837ee3250-DataRef",
+    "subscripts": [
+      "0x61a837e5f1b0-SectionSubscript",
+      "0x61a837e5c300-SectionSubscript"]
+  },
+  {
+    "id": "0x61a837ee3250-DataRef",
+    "value": "0x61a837ee3250-Name"
+  },
+  {
+    "id": "0x61a837ee3250-Name",
+    "source": "matrix"
+  },
+  {
+    "id": "0x61a837e5f1b0-SectionSubscript",
+    "value": "0x61a837e4ab40-Expr"
+  },
+  {
+    "id": "0x61a837e4ab40-Expr",
+    "value": "0x61a837e4ab60-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4ab60-LiteralConstant",
+    "value": "0x61a837e4ab60-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4ab60-IntLiteralConstant",
+    "CharBlock": "1"
+  },
+  {
+    "id": "0x61a837e5c300-SectionSubscript",
+    "value": "0x61a837e4e0e0-Expr"
+  },
+  {
+    "id": "0x61a837e4e0e0-Expr",
+    "value": "0x61a837e4e100-LiteralConstant"
+  },
+  {
+    "id": "0x61a837e4e100-LiteralConstant",
+    "value": "0x61a837e4e100-IntLiteralConstant"
+  },
+  {
+    "id": "0x61a837e4e100-IntLiteralConstant",
+    "CharBlock": "2"
+  },
+  {
+    "id": "0x61a837e4dba0-Statement",
+    "statement": "0x61a837e4dbb0-EndProgramStmt",
+    "label": "null",
+    "source": "end program array_demonstration"
+  },
+  {
+    "id": "0x61a837e4dbb0-EndProgramStmt",
+    "Name": "0x61a837e4dbb0-Name"
+  },
+  {
+    "id": "0x61a837e4dbb0-Name",
+    "source": "array_demonstration"
+  }],
+  "enums": {
+    "Fortran::common::CUDADataAttr": ["Constant", "Device", "Managed", "Pinned", "Shared", "Texture", "Unified"],
+    "Fortran::common::CUDASubprogramAttrs": ["Host", "Device", "HostDevice", "Global", "Grid_Global"],
+    "Fortran::common::OpenACCDeviceType": ["Star", "Default", "Nvidia", "Radeon", "Host", "Multicore", "None"],
+    "Fortran::parser::AccDataModifier::Modifier": ["ReadOnly", "Zero"],
+    "Fortran::parser::AccessSpec::Kind": ["Public", "Private"],
+    "Fortran::parser::BindEntity::Kind": ["Object", "Common"],
+    "Fortran::parser::ConnectSpec::CharExpr::Kind": ["Access", "Action", "Asynchronous", "Blank", "Decimal", "Delim", "Encoding", "Form", "Pad", "Position", "Round", "Sign", "Carriagecontrol", "Convert", "Dispose"],
+    "Fortran::parser::DefinedOperator::IntrinsicOperator": ["Power", "Multiply", "Divide", "Add", "Subtract", "Concat", "LT", "LE", "EQ", "NE", "GE", "GT", "NOT", "AND", "OR", "EQV", "NEQV"],
+    "Fortran::parser::ImplicitStmt::ImplicitNoneNameSpec": ["External", "Type"],
+    "Fortran::parser::InquireSpec::CharVar::Kind": ["Access", "Action", "Asynchronous", "Blank", "Decimal", "Delim", "Direct", "Encoding", "Form", "Formatted", "Iomsg", "Name", "Pad", "Position", "Read", "Readwrite", "Round", "Sequential", "Sign", "Stream", "Status", "Unformatted", "Write", "Carriagecontrol", "Convert", "Dispose"],
+    "Fortran::parser::InquireSpec::IntVar::Kind": ["Iostat", "Nextrec", "Number", "Pos", "Recl", "Size"],
+    "Fortran::parser::InquireSpec::LogVar::Kind": ["Exist", "Named", "Opened", "Pending"],
+    "Fortran::parser::IntentSpec::Intent": ["In", "Out", "InOut"],
+    "Fortran::parser::IoControlSpec::CharExpr::Kind": ["Advance", "Blank", "Decimal", "Delim", "Pad", "Round", "Sign"],
+    "Fortran::parser::ReductionOperator::Operator": ["Plus", "Multiply", "Max", "Min", "Iand", "Ior", "Ieor", "And", "Or", "Eqv", "Neqv"],
+    "Fortran::parser::OmpTraitSelectorName::Value": ["Arch", "Atomic_Default_Mem_Order", "Condition", "Device_Num", "Extension", "Isa", "Kind", "Requires", "Simd", "Uid", "Vendor"],
+    "Fortran::parser::OmpTraitSetSelectorName::Value": ["Construct", "Device", "Implementation", "Target_Device", "User"],
+    "Fortran::parser::OmpMapType::Value": ["Alloc", "Delete", "From", "Release", "To", "Tofrom"],
+    "Fortran::parser::OmpMapTypeModifier::Value": ["Always", "Close", "Present", "Ompx_Hold"],
+    "Fortran::parser::OmpAtClause::ActionTime": ["Compilation", "Execution"],
+    "Fortran::parser::OmpSeverityClause::Severity": ["Fatal", "Warning"],
+    "Fortran::parser::OmpCancelType::Type": ["Parallel", "Sections", "Do", "Taskgroup"],
+    "Fortran::parser::OmpDefaultClause::DataSharingAttribute": ["Private", "Firstprivate", "Shared", "None"],
+    "Fortran::parser::OmpVariableCategory::Value": ["Aggregate", "All", "Allocatable", "Pointer", "Scalar"],
+    "Fortran::parser::OmpDefaultmapClause::ImplicitBehavior": ["Alloc", "To", "From", "Tofrom", "Firstprivate", "None", "Default"],
+    "Fortran::parser::OmpDependenceType::Value": ["Sink", "Source"],
+    "Fortran::parser::OmpTaskDependenceType::Value": ["In", "Out", "Inout", "Inoutset", "Mutexinoutset", "Depobj"],
+    "Fortran::parser::OmpExpectation::Value": ["Present"],
+    "Fortran::parser::OmpLastprivateModifier::Value": ["Conditional"],
+    "Fortran::parser::OmpLinearModifier::Value": ["Ref", "Uval", "Val"],
+    "Fortran::parser::OmpOrderClause::Ordering": ["Concurrent"],
+    "Fortran::parser::OmpOrderModifier::Value": ["Reproducible", "Unconstrained"],
+    "Fortran::parser::OmpPrescriptiveness::Value": ["Strict"],
+    "Fortran::parser::OmpBindClause::Binding": ["Parallel", "Teams", "Thread"],
+    "Fortran::parser::OmpProcBindClause::AffinityPolicy": ["Close", "Master", "Spread", "Primary"],
+    "Fortran::parser::OmpReductionModifier::Value": ["Default", "Inscan", "Task"],
+    "Fortran::parser::OmpScheduleClause::Kind": ["Static", "Dynamic", "Guided", "Auto", "Runtime"],
+    "Fortran::parser::OmpDeviceModifier::Value": ["Ancestor", "Device_Num"],
+    "Fortran::parser::OmpDeviceTypeClause::DeviceTypeDescription": ["Any", "Host", "Nohost"],
+    "Fortran::parser::OmpChunkModifier::Value": ["Simd"],
+    "Fortran::parser::OmpOrderingModifier::Value": ["Monotonic", "Nonmonotonic", "Simd"],
+    "Fortran::common::OmpAtomicDefaultMemOrderType": ["SeqCst", "AcqRel", "Relaxed"],
+    "Fortran::parser::ProcedureStmt::Kind": ["ModuleProcedure", "Procedure"],
+    "Fortran::parser::SavedEntity::Kind": ["Entity", "Common"],
+    "Fortran::parser::StopStmt::Kind": ["Stop", "ErrorStop"],
+    "Fortran::parser::UseStmt::ModuleNature": ["Intrinsic", "Non_Intrinsic"]
+  }
+}

--- a/FortranParser/resources-test/fortran/parser/do.json
+++ b/FortranParser/resources-test/fortran/parser/do.json
@@ -1,564 +1,390 @@
 {"nodes": [
   {
-    "id": "0x7fffbd6d9400-Program",
+    "id": "0x7fffc6984400-Program",
     "ProgramUnit": [
-      "0x7fffbd703440-ProgramUnit"]
+      "0x7fffc69b2030-ProgramUnit"]
   },
   {
-    "id": "0x7fffbd703440-ProgramUnit",
-    "value": "0x7fffbd706270-MainProgram"
+    "id": "0x7fffc69b2030-ProgramUnit",
+    "value": "0x7fffc69b2d20-MainProgram"
   },
   {
-    "id": "0x7fffbd706270-MainProgram",
-    "Statement<ProgramStmt>": "0x7fffbd7063b8-Statement",
-    "SpecificationPart": "0x7fffbd706310-SpecificationPart",
-    "ExecutionPart": "0x7fffbd7062f8-ExecutionPart",
-    "Statement<EndProgramStmt>": "0x7fffbd706270-Statement"
+    "id": "0x7fffc69b2d20-MainProgram",
+    "Statement<ProgramStmt>": "0x7fffc69b2e68-Statement",
+    "SpecificationPart": "0x7fffc69b2dc0-SpecificationPart",
+    "ExecutionPart": "0x7fffc69b2da8-ExecutionPart",
+    "Statement<EndProgramStmt>": "0x7fffc69b2d20-Statement"
   },
   {
-    "id": "0x7fffbd7063b8-Statement",
-    "statement": "0x7fffbd7063c8-ProgramStmt",
+    "id": "0x7fffc69b2e68-Statement",
+    "statement": "0x7fffc69b2e78-ProgramStmt",
     "label": "null",
-    "source": "program simple_loop"
+    "source": "program array_demonstration"
   },
   {
-    "id": "0x7fffbd7063c8-ProgramStmt",
-    "Name": "0x7fffbd7063c8-Name"
+    "id": "0x7fffc69b2e78-ProgramStmt",
+    "Name": "0x7fffc69b2e78-Name"
   },
   {
-    "id": "0x7fffbd7063c8-Name",
-    "source": "simple_loop"
+    "id": "0x7fffc69b2e78-Name",
+    "source": "array_demonstration"
   },
   {
-    "id": "0x7fffbd706310-SpecificationPart",
-    "ImplicitPart": "0x7fffbd706328-ImplicitPart",
+    "id": "0x7fffc69b2dc0-SpecificationPart",
+    "ImplicitPart": "0x7fffc69b2dd8-ImplicitPart",
     "DeclarationConstruct": [
-      "0x7fffbd6df980-DeclarationConstruct"]
+      "0x7fffc69b0220-DeclarationConstruct"]
   },
   {
-    "id": "0x7fffbd706328-ImplicitPart"
+    "id": "0x7fffc69b2dd8-ImplicitPart",
+    "ImplicitPartStmt": [
+      "0x7fffc69acdb0-ImplicitPartStmt"]
   },
   {
-    "id": "0x7fffbd6df980-DeclarationConstruct",
-    "value": "0x7fffbd6df980-SpecificationConstruct"
+    "id": "0x7fffc69acdb0-ImplicitPartStmt",
+    "value<ImplicitStmt>": "0x7fffc69acdb0-Statement"
   },
   {
-    "id": "0x7fffbd6df980-SpecificationConstruct",
-    "value<TypeDeclarationStmt>": "0x7fffbd6df980-Statement"
-  },
-  {
-    "id": "0x7fffbd6df980-Statement",
-    "statement": "0x7fffbd6e78b0-TypeDeclarationStmt",
+    "id": "0x7fffc69acdb0-Statement",
+    "statement": "0x7fffc69ae720-ImplicitStmt",
     "label": "null",
-    "source": "integer :: i, dummy, a = 2"
+    "source": "implicit none"
   },
   {
-    "id": "0x7fffbd6e78b0-TypeDeclarationStmt",
-    "DeclarationTypeSpec": "0x7fffbd6e78e0-DeclarationTypeSpec",
+    "id": "0x7fffc69ae720-ImplicitStmt",
+    "value": [
+    ]
+  },
+  {
+    "id": "0x7fffc69b0220-DeclarationConstruct",
+    "value": "0x7fffc69b0220-SpecificationConstruct"
+  },
+  {
+    "id": "0x7fffc69b0220-SpecificationConstruct",
+    "value<TypeDeclarationStmt>": "0x7fffc69b0220-Statement"
+  },
+  {
+    "id": "0x7fffc69b0220-Statement",
+    "statement": "0x7fffc6992910-TypeDeclarationStmt",
+    "label": "null",
+    "source": "integer :: vec(5) = [10, 20, 30, 40, 50]"
+  },
+  {
+    "id": "0x7fffc6992910-TypeDeclarationStmt",
+    "DeclarationTypeSpec": "0x7fffc6992940-DeclarationTypeSpec",
     "EntityDecl": [
-      "0x7fffbd703b10-EntityDecl",
-      "0x7fffbd6b30d0-EntityDecl",
-      "0x7fffbd703a20-EntityDecl"]
+      "0x7fffc69b0050-EntityDecl"]
   },
   {
-    "id": "0x7fffbd6e78e0-DeclarationTypeSpec",
-    "value": "0x7fffbd6e78e0-IntrinsicTypeSpec"
+    "id": "0x7fffc6992940-DeclarationTypeSpec",
+    "value": "0x7fffc6992940-IntrinsicTypeSpec"
   },
   {
-    "id": "0x7fffbd6e78e0-IntrinsicTypeSpec",
-    "value": "0x7fffbd6e78e0-IntegerTypeSpec"
+    "id": "0x7fffc6992940-IntrinsicTypeSpec",
+    "value": "0x7fffc6992940-IntegerTypeSpec"
   },
   {
-    "id": "0x7fffbd6e78e0-IntegerTypeSpec"
+    "id": "0x7fffc6992940-IntegerTypeSpec"
   },
   {
-    "id": "0x7fffbd703b10-EntityDecl",
-    "Name": "0x7fffbd703bc8-Name"
+    "id": "0x7fffc69b0050-EntityDecl",
+    "Name": "0x7fffc69b0108-Name",
+    "ArraySpec": "0x7fffc69b00d0-ArraySpec",
+    "Initialization": "0x7fffc69b0050-Initialization"
   },
   {
-    "id": "0x7fffbd703bc8-Name",
-    "source": "i"
+    "id": "0x7fffc69b0108-Name",
+    "source": "vec"
   },
   {
-    "id": "0x7fffbd6b30d0-EntityDecl",
-    "Name": "0x7fffbd6b3188-Name"
+    "id": "0x7fffc69b00d0-ArraySpec",
+    "value": [
+      "0x7fffc69acd20-ExplicitShapeSpec"]
   },
   {
-    "id": "0x7fffbd6b3188-Name",
-    "source": "dummy"
+    "id": "0x7fffc69acd20-ExplicitShapeSpec",
+    "upper_bound": "0x7fffc69acd20-SpecificationExpr"
   },
   {
-    "id": "0x7fffbd703a20-EntityDecl",
-    "Name": "0x7fffbd703ad8-Name",
-    "Initialization": "0x7fffbd703a20-Initialization"
+    "id": "0x7fffc69acd20-SpecificationExpr",
+    "Expr": "0x7fffc69ae7c0-Expr"
   },
   {
-    "id": "0x7fffbd703ad8-Name",
-    "source": "a"
+    "id": "0x7fffc69ae7c0-Expr",
+    "value": "0x7fffc69ae7e0-LiteralConstant"
   },
   {
-    "id": "0x7fffbd703a20-Initialization",
-    "value": "0x7fffbd703a20-Constant"
+    "id": "0x7fffc69ae7e0-LiteralConstant",
+    "value": "0x7fffc69ae7e0-IntLiteralConstant"
   },
   {
-    "id": "0x7fffbd703a20-Constant",
-    "value": "0x7fffbd703950-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd703930-Expr",
-    "value": "0x7fffbd703950-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd703950-LiteralConstant",
-    "value": "0x7fffbd703950-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffbd703950-IntLiteralConstant",
-    "CharBlock": "2"
-  },
-  {
-    "id": "0x7fffbd7062f8-ExecutionPart",
-    "ExecutionPartConstruct": [
-      "0x7fffbd7048f0-ExecutionPartConstruct",
-      "0x7fffbd705500-ExecutionPartConstruct",
-      "0x7fffbd705ea0-ExecutionPartConstruct"]
-  },
-  {
-    "id": "0x7fffbd7062f8-ExecutionPartConstruct"
-  },
-  {
-    "id": "0x7fffbd7048f0-ExecutionPartConstruct",
-    "value": "0x7fffbd7048f0-ExecutableConstruct"
-  },
-  {
-    "id": "0x7fffbd7048f0-ExecutableConstruct",
-    "value": "0x7fffbd6c4490-DoConstruct"
-  },
-  {
-    "id": "0x7fffbd6c4490-DoConstruct",
-    "Statement<NonLabelDoStmt>": "0x7fffbd6c44e8-Statement",
-    "ExecutionPartConstruct": [
-      "0x7fffbd703870-ExecutionPartConstruct",
-      "0x7fffbd705780-ExecutionPartConstruct"],
-    "Statement<EndDoStmt>": "0x7fffbd6c4490-Statement"
-  },
-  {
-    "id": "0x7fffbd6c44e8-Statement",
-    "statement": "0x7fffbd6c44f8-NonLabelDoStmt",
-    "label": "null",
-    "source": "do i = 1, 5, a"
-  },
-  {
-    "id": "0x7fffbd6c44f8-NonLabelDoStmt",
-    "LoopControl": "0x7fffbd6c44f8-LoopControl"
-  },
-  {
-    "id": "0x7fffbd6c44f8-LoopControl",
-    "value": "0x7fffbd6c44f8-LoopBounds",
-    "kind": "Range"
-  },
-  {
-    "id": "0x7fffbd6c44f8-LoopBounds",
-    "var": "0x7fffbd6c44f8-Name",
-    "lower": "0x7fffbd705190-Expr",
-    "upper": "0x7fffbd705270-Expr",
-    "step": "0x7fffbd7053b0-Expr"
-  },
-  {
-    "id": "0x7fffbd6c44f8-Name",
-    "source": "i"
-  },
-  {
-    "id": "0x7fffbd705190-Expr",
-    "value": "0x7fffbd7051b0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd7051b0-LiteralConstant",
-    "value": "0x7fffbd7051b0-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffbd7051b0-IntLiteralConstant",
-    "CharBlock": "1"
-  },
-  {
-    "id": "0x7fffbd705270-Expr",
-    "value": "0x7fffbd705290-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705290-LiteralConstant",
-    "value": "0x7fffbd705290-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705290-IntLiteralConstant",
+    "id": "0x7fffc69ae7e0-IntLiteralConstant",
     "CharBlock": "5"
   },
   {
-    "id": "0x7fffbd7053b0-Expr",
-    "value": "0x7fffbd705350-Designator"
+    "id": "0x7fffc69b0050-Initialization",
+    "value": "0x7fffc69aff60-Expr"
   },
   {
-    "id": "0x7fffbd705350-Designator",
-    "value": "0x7fffbd705360-DataRef"
+    "id": "0x7fffc69aff60-Expr",
+    "value": "0x7fffc69aff80-ArrayConstructor"
   },
   {
-    "id": "0x7fffbd705360-DataRef",
-    "value": "0x7fffbd705360-Name"
+    "id": "0x7fffc69aff80-ArrayConstructor",
+    "AcSpec": "0x7fffc69aff80-AcSpec"
   },
   {
-    "id": "0x7fffbd705360-Name",
-    "source": "a"
+    "id": "0x7fffc69aff80-AcSpec",
+    "values": [
+      "0x7fffc69ada00-AcValue",
+      "0x7fffc69ace00-AcValue",
+      "0x7fffc69ace90-AcValue",
+      "0x7fffc69ad910-AcValue",
+      "0x7fffc69ad9c0-AcValue"]
   },
   {
-    "id": "0x7fffbd6c44d0-ExecutionPartConstruct"
+    "id": "0x7fffc69ada00-AcValue",
+    "value": "0x7fffc69af1a0-Expr"
   },
   {
-    "id": "0x7fffbd703870-ExecutionPartConstruct",
-    "value": "0x7fffbd703870-ExecutableConstruct"
+    "id": "0x7fffc69af1a0-Expr",
+    "value": "0x7fffc69af1c0-LiteralConstant"
   },
   {
-    "id": "0x7fffbd703870-ExecutableConstruct",
-    "value<ActionStmt>": "0x7fffbd703870-Statement"
+    "id": "0x7fffc69af1c0-LiteralConstant",
+    "value": "0x7fffc69af1c0-IntLiteralConstant"
   },
   {
-    "id": "0x7fffbd703870-Statement",
-    "statement": "0x7fffbd703880-ActionStmt",
-    "label": "null",
-    "source": "dummy = 3"
+    "id": "0x7fffc69af1c0-IntLiteralConstant",
+    "CharBlock": "10"
   },
   {
-    "id": "0x7fffbd703880-ActionStmt",
-    "value": "0x7fffbd705550-AssignmentStmt"
+    "id": "0x7fffc69ace00-AcValue",
+    "value": "0x7fffc69af4a0-Expr"
   },
   {
-    "id": "0x7fffbd705550-AssignmentStmt",
-    "Variable": "0x7fffbd705630-Variable",
-    "Expr": "0x7fffbd705560-Expr"
+    "id": "0x7fffc69af4a0-Expr",
+    "value": "0x7fffc69af4c0-LiteralConstant"
   },
   {
-    "id": "0x7fffbd705630-Variable",
-    "value": "0x7fffbd6dfce0-Designator"
+    "id": "0x7fffc69af4c0-LiteralConstant",
+    "value": "0x7fffc69af4c0-IntLiteralConstant"
   },
   {
-    "id": "0x7fffbd6dfce0-Designator",
-    "value": "0x7fffbd6dfcf0-DataRef"
+    "id": "0x7fffc69af4c0-IntLiteralConstant",
+    "CharBlock": "20"
   },
   {
-    "id": "0x7fffbd6dfcf0-DataRef",
-    "value": "0x7fffbd6dfcf0-Name"
+    "id": "0x7fffc69ace90-AcValue",
+    "value": "0x7fffc69af7a0-Expr"
   },
   {
-    "id": "0x7fffbd6dfcf0-Name",
-    "source": "dummy"
+    "id": "0x7fffc69af7a0-Expr",
+    "value": "0x7fffc69af7c0-LiteralConstant"
   },
   {
-    "id": "0x7fffbd705560-Expr",
-    "value": "0x7fffbd705580-LiteralConstant"
+    "id": "0x7fffc69af7c0-LiteralConstant",
+    "value": "0x7fffc69af7c0-IntLiteralConstant"
   },
   {
-    "id": "0x7fffbd705580-LiteralConstant",
-    "value": "0x7fffbd705580-IntLiteralConstant"
+    "id": "0x7fffc69af7c0-IntLiteralConstant",
+    "CharBlock": "30"
   },
   {
-    "id": "0x7fffbd705580-IntLiteralConstant",
-    "CharBlock": "3"
+    "id": "0x7fffc69ad910-AcValue",
+    "value": "0x7fffc69afaa0-Expr"
   },
   {
-    "id": "0x7fffbd705780-ExecutionPartConstruct",
-    "value": "0x7fffbd705780-ExecutableConstruct"
+    "id": "0x7fffc69afaa0-Expr",
+    "value": "0x7fffc69afac0-LiteralConstant"
   },
   {
-    "id": "0x7fffbd705780-ExecutableConstruct",
-    "value<ActionStmt>": "0x7fffbd705780-Statement"
+    "id": "0x7fffc69afac0-LiteralConstant",
+    "value": "0x7fffc69afac0-IntLiteralConstant"
   },
   {
-    "id": "0x7fffbd705780-Statement",
-    "statement": "0x7fffbd705790-ActionStmt",
-    "label": "null",
-    "source": "dummy = 4"
+    "id": "0x7fffc69afac0-IntLiteralConstant",
+    "CharBlock": "40"
   },
   {
-    "id": "0x7fffbd705790-ActionStmt",
-    "value": "0x7fffbd705660-AssignmentStmt"
+    "id": "0x7fffc69ad9c0-AcValue",
+    "value": "0x7fffc69afda0-Expr"
   },
   {
-    "id": "0x7fffbd705660-AssignmentStmt",
-    "Variable": "0x7fffbd705740-Variable",
-    "Expr": "0x7fffbd705670-Expr"
+    "id": "0x7fffc69afda0-Expr",
+    "value": "0x7fffc69afdc0-LiteralConstant"
   },
   {
-    "id": "0x7fffbd705740-Variable",
-    "value": "0x7fffbd6d9230-Designator"
+    "id": "0x7fffc69afdc0-LiteralConstant",
+    "value": "0x7fffc69afdc0-IntLiteralConstant"
   },
   {
-    "id": "0x7fffbd6d9230-Designator",
-    "value": "0x7fffbd6d9240-DataRef"
+    "id": "0x7fffc69afdc0-IntLiteralConstant",
+    "CharBlock": "50"
   },
   {
-    "id": "0x7fffbd6d9240-DataRef",
-    "value": "0x7fffbd6d9240-Name"
-  },
-  {
-    "id": "0x7fffbd6d9240-Name",
-    "source": "dummy"
-  },
-  {
-    "id": "0x7fffbd705670-Expr",
-    "value": "0x7fffbd705690-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705690-LiteralConstant",
-    "value": "0x7fffbd705690-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705690-IntLiteralConstant",
-    "CharBlock": "4"
-  },
-  {
-    "id": "0x7fffbd6c4490-Statement",
-    "statement": "0x7fffbd6c44a0-EndDoStmt",
-    "label": "null",
-    "source": "end do"
-  },
-  {
-    "id": "0x7fffbd6c44a0-EndDoStmt"
-  },
-  {
-    "id": "0x7fffbd705500-ExecutionPartConstruct",
-    "value": "0x7fffbd705500-ExecutableConstruct"
-  },
-  {
-    "id": "0x7fffbd705500-ExecutableConstruct",
-    "value": "0x7fffbd705d10-DoConstruct"
-  },
-  {
-    "id": "0x7fffbd705d10-DoConstruct",
-    "Statement<NonLabelDoStmt>": "0x7fffbd705d68-Statement",
+    "id": "0x7fffc69b2da8-ExecutionPart",
     "ExecutionPartConstruct": [
-      "0x7fffbd705cc0-ExecutionPartConstruct"],
-    "Statement<EndDoStmt>": "0x7fffbd705d10-Statement"
+      "0x7fffc69af290-ExecutionPartConstruct",
+      "0x7fffc69b1160-ExecutionPartConstruct"]
   },
   {
-    "id": "0x7fffbd705d68-Statement",
-    "statement": "0x7fffbd705d78-NonLabelDoStmt",
+    "id": "0x7fffc69b2da8-ExecutionPartConstruct"
+  },
+  {
+    "id": "0x7fffc69af290-ExecutionPartConstruct",
+    "value": "0x7fffc69af290-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffc69af290-ExecutableConstruct",
+    "value<ActionStmt>": "0x7fffc69af290-Statement"
+  },
+  {
+    "id": "0x7fffc69af290-Statement",
+    "statement": "0x7fffc69af2a0-ActionStmt",
     "label": "null",
-    "source": "do while(2 > 0)"
+    "source": "print *, \"--- 1. Simple Indexing ---\""
   },
   {
-    "id": "0x7fffbd705d78-NonLabelDoStmt",
-    "LoopControl": "0x7fffbd705d78-LoopControl"
+    "id": "0x7fffc69af2a0-ActionStmt",
+    "value": "0x7fffc69aebd0-PrintStmt"
   },
   {
-    "id": "0x7fffbd705d78-LoopControl",
-    "value": "0x7fffbd705a00-Expr",
-    "kind": "While"
+    "id": "0x7fffc69aebd0-PrintStmt",
+    "Format": "0x7fffc69aebe8-Format",
+    "OutputItem": [
+      "0x7fffc69aea80-OutputItem"]
   },
   {
-    "id": "0x7fffbd705a00-Expr",
-    "value": "0x7fffbd705a20-GT"
+    "id": "0x7fffc69aebe8-Format",
+    "value": "0x7fffc69aebe8-Star"
   },
   {
-    "id": "0x7fffbd705a20-GT",
-    "left": "0x7fffbd705920-Expr",
-    "right": "0x7fffbd705840-Expr",
-    "op": "GT"
+    "id": "0x7fffc69aebe8-Star"
   },
   {
-    "id": "0x7fffbd705920-Expr",
-    "value": "0x7fffbd705940-LiteralConstant"
+    "id": "0x7fffc69aea80-OutputItem",
+    "value": "0x7fffc69aea80-Expr"
   },
   {
-    "id": "0x7fffbd705940-LiteralConstant",
-    "value": "0x7fffbd705940-IntLiteralConstant"
+    "id": "0x7fffc69aea80-Expr",
+    "value": "0x7fffc69aeaa0-LiteralConstant"
   },
   {
-    "id": "0x7fffbd705940-IntLiteralConstant",
+    "id": "0x7fffc69aeaa0-LiteralConstant",
+    "value": "0x7fffc69aeaa0-CharLiteralConstant"
+  },
+  {
+    "id": "0x7fffc69aeaa0-CharLiteralConstant",
+    "string": "--- 1. Simple Indexing ---"
+  },
+  {
+    "id": "0x7fffc69b1160-ExecutionPartConstruct",
+    "value": "0x7fffc69b1160-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffc69b1160-ExecutableConstruct",
+    "value<ActionStmt>": "0x7fffc69b1160-Statement"
+  },
+  {
+    "id": "0x7fffc69b1160-Statement",
+    "statement": "0x7fffc69b1170-ActionStmt",
+    "label": "null",
+    "source": "print *, \"The second element is:\", vec(2)"
+  },
+  {
+    "id": "0x7fffc69b1170-ActionStmt",
+    "value": "0x7fffc69b0fe0-PrintStmt"
+  },
+  {
+    "id": "0x7fffc69b0fe0-PrintStmt",
+    "Format": "0x7fffc69b0ff8-Format",
+    "OutputItem": [
+      "0x7fffc69b0e90-OutputItem",
+      "0x7fffc69b0da0-OutputItem"]
+  },
+  {
+    "id": "0x7fffc69b0ff8-Format",
+    "value": "0x7fffc69b0ff8-Star"
+  },
+  {
+    "id": "0x7fffc69b0ff8-Star"
+  },
+  {
+    "id": "0x7fffc69b0e90-OutputItem",
+    "value": "0x7fffc69b0e90-Expr"
+  },
+  {
+    "id": "0x7fffc69b0e90-Expr",
+    "value": "0x7fffc69b0eb0-LiteralConstant"
+  },
+  {
+    "id": "0x7fffc69b0eb0-LiteralConstant",
+    "value": "0x7fffc69b0eb0-CharLiteralConstant"
+  },
+  {
+    "id": "0x7fffc69b0eb0-CharLiteralConstant",
+    "string": "The second element is:"
+  },
+  {
+    "id": "0x7fffc69b0da0-OutputItem",
+    "value": "0x7fffc69b0da0-Expr"
+  },
+  {
+    "id": "0x7fffc69b0da0-Expr",
+    "value": "0x7fffc69c3530-Designator"
+  },
+  {
+    "id": "0x7fffc69c3530-Designator",
+    "value": "0x7fffc69c3540-DataRef"
+  },
+  {
+    "id": "0x7fffc69c3540-DataRef",
+    "value": "0x7fffc6a454a0-ArrayElement"
+  },
+  {
+    "id": "0x7fffc6a454a0-ArrayElement",
+    "base": "0x7fffc6a454a0-DataRef",
+    "subscripts": [
+      "0x7fffc69ace40-SectionSubscript"]
+  },
+  {
+    "id": "0x7fffc6a454a0-DataRef",
+    "value": "0x7fffc6a454a0-Name"
+  },
+  {
+    "id": "0x7fffc6a454a0-Name",
+    "source": "vec"
+  },
+  {
+    "id": "0x7fffc69ace40-SectionSubscript",
+    "value": "0x7fffc69b3a60-Expr"
+  },
+  {
+    "id": "0x7fffc69b3a60-Expr",
+    "value": "0x7fffc69b3a80-LiteralConstant"
+  },
+  {
+    "id": "0x7fffc69b3a80-LiteralConstant",
+    "value": "0x7fffc69b3a80-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffc69b3a80-IntLiteralConstant",
     "CharBlock": "2"
   },
   {
-    "id": "0x7fffbd705840-Expr",
-    "value": "0x7fffbd705860-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705860-LiteralConstant",
-    "value": "0x7fffbd705860-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705860-IntLiteralConstant",
-    "CharBlock": "0"
-  },
-  {
-    "id": "0x7fffbd705d50-ExecutionPartConstruct"
-  },
-  {
-    "id": "0x7fffbd705cc0-ExecutionPartConstruct",
-    "value": "0x7fffbd705cc0-ExecutableConstruct"
-  },
-  {
-    "id": "0x7fffbd705cc0-ExecutableConstruct",
-    "value<ActionStmt>": "0x7fffbd705cc0-Statement"
-  },
-  {
-    "id": "0x7fffbd705cc0-Statement",
-    "statement": "0x7fffbd705cd0-ActionStmt",
+    "id": "0x7fffc69b2d20-Statement",
+    "statement": "0x7fffc69b2d30-EndProgramStmt",
     "label": "null",
-    "source": "dummy = 2"
+    "source": "end program array_demonstration"
   },
   {
-    "id": "0x7fffbd705cd0-ActionStmt",
-    "value": "0x7fffbd705ba0-AssignmentStmt"
+    "id": "0x7fffc69b2d30-EndProgramStmt",
+    "Name": "0x7fffc69b2d30-Name"
   },
   {
-    "id": "0x7fffbd705ba0-AssignmentStmt",
-    "Variable": "0x7fffbd705c80-Variable",
-    "Expr": "0x7fffbd705bb0-Expr"
-  },
-  {
-    "id": "0x7fffbd705c80-Variable",
-    "value": "0x7fffbd705490-Designator"
-  },
-  {
-    "id": "0x7fffbd705490-Designator",
-    "value": "0x7fffbd7054a0-DataRef"
-  },
-  {
-    "id": "0x7fffbd7054a0-DataRef",
-    "value": "0x7fffbd7054a0-Name"
-  },
-  {
-    "id": "0x7fffbd7054a0-Name",
-    "source": "dummy"
-  },
-  {
-    "id": "0x7fffbd705bb0-Expr",
-    "value": "0x7fffbd705bd0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705bd0-LiteralConstant",
-    "value": "0x7fffbd705bd0-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705bd0-IntLiteralConstant",
-    "CharBlock": "2"
-  },
-  {
-    "id": "0x7fffbd705d10-Statement",
-    "statement": "0x7fffbd705d20-EndDoStmt",
-    "label": "null",
-    "source": "end do"
-  },
-  {
-    "id": "0x7fffbd705d20-EndDoStmt"
-  },
-  {
-    "id": "0x7fffbd705ea0-ExecutionPartConstruct",
-    "value": "0x7fffbd705ea0-ExecutableConstruct"
-  },
-  {
-    "id": "0x7fffbd705ea0-ExecutableConstruct",
-    "value": "0x7fffbd706060-DoConstruct"
-  },
-  {
-    "id": "0x7fffbd706060-DoConstruct",
-    "Statement<NonLabelDoStmt>": "0x7fffbd7060b8-Statement",
-    "ExecutionPartConstruct": [
-      "0x7fffbd706010-ExecutionPartConstruct"],
-    "Statement<EndDoStmt>": "0x7fffbd706060-Statement"
-  },
-  {
-    "id": "0x7fffbd7060b8-Statement",
-    "statement": "0x7fffbd7060c8-NonLabelDoStmt",
-    "label": "null",
-    "source": "name: do"
-  },
-  {
-    "id": "0x7fffbd7060c8-NonLabelDoStmt",
-    "Name": "0x7fffbd706148-Name"
-  },
-  {
-    "id": "0x7fffbd706148-Name",
-    "source": "name"
-  },
-  {
-    "id": "0x7fffbd7060a0-ExecutionPartConstruct"
-  },
-  {
-    "id": "0x7fffbd706010-ExecutionPartConstruct",
-    "value": "0x7fffbd706010-ExecutableConstruct"
-  },
-  {
-    "id": "0x7fffbd706010-ExecutableConstruct",
-    "value<ActionStmt>": "0x7fffbd706010-Statement"
-  },
-  {
-    "id": "0x7fffbd706010-Statement",
-    "statement": "0x7fffbd706020-ActionStmt",
-    "label": "null",
-    "source": "dummy = 4"
-  },
-  {
-    "id": "0x7fffbd706020-ActionStmt",
-    "value": "0x7fffbd705ef0-AssignmentStmt"
-  },
-  {
-    "id": "0x7fffbd705ef0-AssignmentStmt",
-    "Variable": "0x7fffbd705fd0-Variable",
-    "Expr": "0x7fffbd705f00-Expr"
-  },
-  {
-    "id": "0x7fffbd705fd0-Variable",
-    "value": "0x7fffbd705e30-Designator"
-  },
-  {
-    "id": "0x7fffbd705e30-Designator",
-    "value": "0x7fffbd705e40-DataRef"
-  },
-  {
-    "id": "0x7fffbd705e40-DataRef",
-    "value": "0x7fffbd705e40-Name"
-  },
-  {
-    "id": "0x7fffbd705e40-Name",
-    "source": "dummy"
-  },
-  {
-    "id": "0x7fffbd705f00-Expr",
-    "value": "0x7fffbd705f20-LiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705f20-LiteralConstant",
-    "value": "0x7fffbd705f20-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffbd705f20-IntLiteralConstant",
-    "CharBlock": "4"
-  },
-  {
-    "id": "0x7fffbd706060-Statement",
-    "statement": "0x7fffbd706070-EndDoStmt",
-    "label": "null",
-    "source": "end do name"
-  },
-  {
-    "id": "0x7fffbd706070-EndDoStmt",
-    "Name": "0x7fffbd706070-Name"
-  },
-  {
-    "id": "0x7fffbd706070-Name",
-    "source": "name"
-  },
-  {
-    "id": "0x7fffbd706270-Statement",
-    "statement": "0x7fffbd706280-EndProgramStmt",
-    "label": "null",
-    "source": "end program simple_loop"
-  },
-  {
-    "id": "0x7fffbd706280-EndProgramStmt",
-    "Name": "0x7fffbd706280-Name"
-  },
-  {
-    "id": "0x7fffbd706280-Name",
-    "source": "simple_loop"
+    "id": "0x7fffc69b2d30-Name",
+    "source": "array_demonstration"
   }],
   "enums": {
     "Fortran::common::CUDADataAttr": ["Constant", "Device", "Managed", "Pinned", "Shared", "Texture", "Unified"],

--- a/FortranParser/resources-test/fortran/parser/do.json
+++ b/FortranParser/resources-test/fortran/parser/do.json
@@ -1,390 +1,564 @@
 {"nodes": [
   {
-    "id": "0x7fffc6984400-Program",
+    "id": "0x7fffbd6d9400-Program",
     "ProgramUnit": [
-      "0x7fffc69b2030-ProgramUnit"]
+      "0x7fffbd703440-ProgramUnit"]
   },
   {
-    "id": "0x7fffc69b2030-ProgramUnit",
-    "value": "0x7fffc69b2d20-MainProgram"
+    "id": "0x7fffbd703440-ProgramUnit",
+    "value": "0x7fffbd706270-MainProgram"
   },
   {
-    "id": "0x7fffc69b2d20-MainProgram",
-    "Statement<ProgramStmt>": "0x7fffc69b2e68-Statement",
-    "SpecificationPart": "0x7fffc69b2dc0-SpecificationPart",
-    "ExecutionPart": "0x7fffc69b2da8-ExecutionPart",
-    "Statement<EndProgramStmt>": "0x7fffc69b2d20-Statement"
+    "id": "0x7fffbd706270-MainProgram",
+    "Statement<ProgramStmt>": "0x7fffbd7063b8-Statement",
+    "SpecificationPart": "0x7fffbd706310-SpecificationPart",
+    "ExecutionPart": "0x7fffbd7062f8-ExecutionPart",
+    "Statement<EndProgramStmt>": "0x7fffbd706270-Statement"
   },
   {
-    "id": "0x7fffc69b2e68-Statement",
-    "statement": "0x7fffc69b2e78-ProgramStmt",
+    "id": "0x7fffbd7063b8-Statement",
+    "statement": "0x7fffbd7063c8-ProgramStmt",
     "label": "null",
-    "source": "program array_demonstration"
+    "source": "program simple_loop"
   },
   {
-    "id": "0x7fffc69b2e78-ProgramStmt",
-    "Name": "0x7fffc69b2e78-Name"
+    "id": "0x7fffbd7063c8-ProgramStmt",
+    "Name": "0x7fffbd7063c8-Name"
   },
   {
-    "id": "0x7fffc69b2e78-Name",
-    "source": "array_demonstration"
+    "id": "0x7fffbd7063c8-Name",
+    "source": "simple_loop"
   },
   {
-    "id": "0x7fffc69b2dc0-SpecificationPart",
-    "ImplicitPart": "0x7fffc69b2dd8-ImplicitPart",
+    "id": "0x7fffbd706310-SpecificationPart",
+    "ImplicitPart": "0x7fffbd706328-ImplicitPart",
     "DeclarationConstruct": [
-      "0x7fffc69b0220-DeclarationConstruct"]
+      "0x7fffbd6df980-DeclarationConstruct"]
   },
   {
-    "id": "0x7fffc69b2dd8-ImplicitPart",
-    "ImplicitPartStmt": [
-      "0x7fffc69acdb0-ImplicitPartStmt"]
+    "id": "0x7fffbd706328-ImplicitPart"
   },
   {
-    "id": "0x7fffc69acdb0-ImplicitPartStmt",
-    "value<ImplicitStmt>": "0x7fffc69acdb0-Statement"
+    "id": "0x7fffbd6df980-DeclarationConstruct",
+    "value": "0x7fffbd6df980-SpecificationConstruct"
   },
   {
-    "id": "0x7fffc69acdb0-Statement",
-    "statement": "0x7fffc69ae720-ImplicitStmt",
+    "id": "0x7fffbd6df980-SpecificationConstruct",
+    "value<TypeDeclarationStmt>": "0x7fffbd6df980-Statement"
+  },
+  {
+    "id": "0x7fffbd6df980-Statement",
+    "statement": "0x7fffbd6e78b0-TypeDeclarationStmt",
     "label": "null",
-    "source": "implicit none"
+    "source": "integer :: i, dummy, a = 2"
   },
   {
-    "id": "0x7fffc69ae720-ImplicitStmt",
-    "value": [
-    ]
-  },
-  {
-    "id": "0x7fffc69b0220-DeclarationConstruct",
-    "value": "0x7fffc69b0220-SpecificationConstruct"
-  },
-  {
-    "id": "0x7fffc69b0220-SpecificationConstruct",
-    "value<TypeDeclarationStmt>": "0x7fffc69b0220-Statement"
-  },
-  {
-    "id": "0x7fffc69b0220-Statement",
-    "statement": "0x7fffc6992910-TypeDeclarationStmt",
-    "label": "null",
-    "source": "integer :: vec(5) = [10, 20, 30, 40, 50]"
-  },
-  {
-    "id": "0x7fffc6992910-TypeDeclarationStmt",
-    "DeclarationTypeSpec": "0x7fffc6992940-DeclarationTypeSpec",
+    "id": "0x7fffbd6e78b0-TypeDeclarationStmt",
+    "DeclarationTypeSpec": "0x7fffbd6e78e0-DeclarationTypeSpec",
     "EntityDecl": [
-      "0x7fffc69b0050-EntityDecl"]
+      "0x7fffbd703b10-EntityDecl",
+      "0x7fffbd6b30d0-EntityDecl",
+      "0x7fffbd703a20-EntityDecl"]
   },
   {
-    "id": "0x7fffc6992940-DeclarationTypeSpec",
-    "value": "0x7fffc6992940-IntrinsicTypeSpec"
+    "id": "0x7fffbd6e78e0-DeclarationTypeSpec",
+    "value": "0x7fffbd6e78e0-IntrinsicTypeSpec"
   },
   {
-    "id": "0x7fffc6992940-IntrinsicTypeSpec",
-    "value": "0x7fffc6992940-IntegerTypeSpec"
+    "id": "0x7fffbd6e78e0-IntrinsicTypeSpec",
+    "value": "0x7fffbd6e78e0-IntegerTypeSpec"
   },
   {
-    "id": "0x7fffc6992940-IntegerTypeSpec"
+    "id": "0x7fffbd6e78e0-IntegerTypeSpec"
   },
   {
-    "id": "0x7fffc69b0050-EntityDecl",
-    "Name": "0x7fffc69b0108-Name",
-    "ArraySpec": "0x7fffc69b00d0-ArraySpec",
-    "Initialization": "0x7fffc69b0050-Initialization"
+    "id": "0x7fffbd703b10-EntityDecl",
+    "Name": "0x7fffbd703bc8-Name"
   },
   {
-    "id": "0x7fffc69b0108-Name",
-    "source": "vec"
+    "id": "0x7fffbd703bc8-Name",
+    "source": "i"
   },
   {
-    "id": "0x7fffc69b00d0-ArraySpec",
-    "value": [
-      "0x7fffc69acd20-ExplicitShapeSpec"]
+    "id": "0x7fffbd6b30d0-EntityDecl",
+    "Name": "0x7fffbd6b3188-Name"
   },
   {
-    "id": "0x7fffc69acd20-ExplicitShapeSpec",
-    "upper_bound": "0x7fffc69acd20-SpecificationExpr"
+    "id": "0x7fffbd6b3188-Name",
+    "source": "dummy"
   },
   {
-    "id": "0x7fffc69acd20-SpecificationExpr",
-    "Expr": "0x7fffc69ae7c0-Expr"
+    "id": "0x7fffbd703a20-EntityDecl",
+    "Name": "0x7fffbd703ad8-Name",
+    "Initialization": "0x7fffbd703a20-Initialization"
   },
   {
-    "id": "0x7fffc69ae7c0-Expr",
-    "value": "0x7fffc69ae7e0-LiteralConstant"
+    "id": "0x7fffbd703ad8-Name",
+    "source": "a"
   },
   {
-    "id": "0x7fffc69ae7e0-LiteralConstant",
-    "value": "0x7fffc69ae7e0-IntLiteralConstant"
+    "id": "0x7fffbd703a20-Initialization",
+    "value": "0x7fffbd703a20-Constant"
   },
   {
-    "id": "0x7fffc69ae7e0-IntLiteralConstant",
-    "CharBlock": "5"
+    "id": "0x7fffbd703a20-Constant",
+    "value": "0x7fffbd703950-LiteralConstant"
   },
   {
-    "id": "0x7fffc69b0050-Initialization",
-    "value": "0x7fffc69aff60-Expr"
+    "id": "0x7fffbd703930-Expr",
+    "value": "0x7fffbd703950-LiteralConstant"
   },
   {
-    "id": "0x7fffc69aff60-Expr",
-    "value": "0x7fffc69aff80-ArrayConstructor"
+    "id": "0x7fffbd703950-LiteralConstant",
+    "value": "0x7fffbd703950-IntLiteralConstant"
   },
   {
-    "id": "0x7fffc69aff80-ArrayConstructor",
-    "AcSpec": "0x7fffc69aff80-AcSpec"
-  },
-  {
-    "id": "0x7fffc69aff80-AcSpec",
-    "values": [
-      "0x7fffc69ada00-AcValue",
-      "0x7fffc69ace00-AcValue",
-      "0x7fffc69ace90-AcValue",
-      "0x7fffc69ad910-AcValue",
-      "0x7fffc69ad9c0-AcValue"]
-  },
-  {
-    "id": "0x7fffc69ada00-AcValue",
-    "value": "0x7fffc69af1a0-Expr"
-  },
-  {
-    "id": "0x7fffc69af1a0-Expr",
-    "value": "0x7fffc69af1c0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69af1c0-LiteralConstant",
-    "value": "0x7fffc69af1c0-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69af1c0-IntLiteralConstant",
-    "CharBlock": "10"
-  },
-  {
-    "id": "0x7fffc69ace00-AcValue",
-    "value": "0x7fffc69af4a0-Expr"
-  },
-  {
-    "id": "0x7fffc69af4a0-Expr",
-    "value": "0x7fffc69af4c0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69af4c0-LiteralConstant",
-    "value": "0x7fffc69af4c0-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69af4c0-IntLiteralConstant",
-    "CharBlock": "20"
-  },
-  {
-    "id": "0x7fffc69ace90-AcValue",
-    "value": "0x7fffc69af7a0-Expr"
-  },
-  {
-    "id": "0x7fffc69af7a0-Expr",
-    "value": "0x7fffc69af7c0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69af7c0-LiteralConstant",
-    "value": "0x7fffc69af7c0-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69af7c0-IntLiteralConstant",
-    "CharBlock": "30"
-  },
-  {
-    "id": "0x7fffc69ad910-AcValue",
-    "value": "0x7fffc69afaa0-Expr"
-  },
-  {
-    "id": "0x7fffc69afaa0-Expr",
-    "value": "0x7fffc69afac0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69afac0-LiteralConstant",
-    "value": "0x7fffc69afac0-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69afac0-IntLiteralConstant",
-    "CharBlock": "40"
-  },
-  {
-    "id": "0x7fffc69ad9c0-AcValue",
-    "value": "0x7fffc69afda0-Expr"
-  },
-  {
-    "id": "0x7fffc69afda0-Expr",
-    "value": "0x7fffc69afdc0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69afdc0-LiteralConstant",
-    "value": "0x7fffc69afdc0-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69afdc0-IntLiteralConstant",
-    "CharBlock": "50"
-  },
-  {
-    "id": "0x7fffc69b2da8-ExecutionPart",
-    "ExecutionPartConstruct": [
-      "0x7fffc69af290-ExecutionPartConstruct",
-      "0x7fffc69b1160-ExecutionPartConstruct"]
-  },
-  {
-    "id": "0x7fffc69b2da8-ExecutionPartConstruct"
-  },
-  {
-    "id": "0x7fffc69af290-ExecutionPartConstruct",
-    "value": "0x7fffc69af290-ExecutableConstruct"
-  },
-  {
-    "id": "0x7fffc69af290-ExecutableConstruct",
-    "value<ActionStmt>": "0x7fffc69af290-Statement"
-  },
-  {
-    "id": "0x7fffc69af290-Statement",
-    "statement": "0x7fffc69af2a0-ActionStmt",
-    "label": "null",
-    "source": "print *, \"--- 1. Simple Indexing ---\""
-  },
-  {
-    "id": "0x7fffc69af2a0-ActionStmt",
-    "value": "0x7fffc69aebd0-PrintStmt"
-  },
-  {
-    "id": "0x7fffc69aebd0-PrintStmt",
-    "Format": "0x7fffc69aebe8-Format",
-    "OutputItem": [
-      "0x7fffc69aea80-OutputItem"]
-  },
-  {
-    "id": "0x7fffc69aebe8-Format",
-    "value": "0x7fffc69aebe8-Star"
-  },
-  {
-    "id": "0x7fffc69aebe8-Star"
-  },
-  {
-    "id": "0x7fffc69aea80-OutputItem",
-    "value": "0x7fffc69aea80-Expr"
-  },
-  {
-    "id": "0x7fffc69aea80-Expr",
-    "value": "0x7fffc69aeaa0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69aeaa0-LiteralConstant",
-    "value": "0x7fffc69aeaa0-CharLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69aeaa0-CharLiteralConstant",
-    "string": "--- 1. Simple Indexing ---"
-  },
-  {
-    "id": "0x7fffc69b1160-ExecutionPartConstruct",
-    "value": "0x7fffc69b1160-ExecutableConstruct"
-  },
-  {
-    "id": "0x7fffc69b1160-ExecutableConstruct",
-    "value<ActionStmt>": "0x7fffc69b1160-Statement"
-  },
-  {
-    "id": "0x7fffc69b1160-Statement",
-    "statement": "0x7fffc69b1170-ActionStmt",
-    "label": "null",
-    "source": "print *, \"The second element is:\", vec(2)"
-  },
-  {
-    "id": "0x7fffc69b1170-ActionStmt",
-    "value": "0x7fffc69b0fe0-PrintStmt"
-  },
-  {
-    "id": "0x7fffc69b0fe0-PrintStmt",
-    "Format": "0x7fffc69b0ff8-Format",
-    "OutputItem": [
-      "0x7fffc69b0e90-OutputItem",
-      "0x7fffc69b0da0-OutputItem"]
-  },
-  {
-    "id": "0x7fffc69b0ff8-Format",
-    "value": "0x7fffc69b0ff8-Star"
-  },
-  {
-    "id": "0x7fffc69b0ff8-Star"
-  },
-  {
-    "id": "0x7fffc69b0e90-OutputItem",
-    "value": "0x7fffc69b0e90-Expr"
-  },
-  {
-    "id": "0x7fffc69b0e90-Expr",
-    "value": "0x7fffc69b0eb0-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69b0eb0-LiteralConstant",
-    "value": "0x7fffc69b0eb0-CharLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69b0eb0-CharLiteralConstant",
-    "string": "The second element is:"
-  },
-  {
-    "id": "0x7fffc69b0da0-OutputItem",
-    "value": "0x7fffc69b0da0-Expr"
-  },
-  {
-    "id": "0x7fffc69b0da0-Expr",
-    "value": "0x7fffc69c3530-Designator"
-  },
-  {
-    "id": "0x7fffc69c3530-Designator",
-    "value": "0x7fffc69c3540-DataRef"
-  },
-  {
-    "id": "0x7fffc69c3540-DataRef",
-    "value": "0x7fffc6a454a0-ArrayElement"
-  },
-  {
-    "id": "0x7fffc6a454a0-ArrayElement",
-    "base": "0x7fffc6a454a0-DataRef",
-    "subscripts": [
-      "0x7fffc69ace40-SectionSubscript"]
-  },
-  {
-    "id": "0x7fffc6a454a0-DataRef",
-    "value": "0x7fffc6a454a0-Name"
-  },
-  {
-    "id": "0x7fffc6a454a0-Name",
-    "source": "vec"
-  },
-  {
-    "id": "0x7fffc69ace40-SectionSubscript",
-    "value": "0x7fffc69b3a60-Expr"
-  },
-  {
-    "id": "0x7fffc69b3a60-Expr",
-    "value": "0x7fffc69b3a80-LiteralConstant"
-  },
-  {
-    "id": "0x7fffc69b3a80-LiteralConstant",
-    "value": "0x7fffc69b3a80-IntLiteralConstant"
-  },
-  {
-    "id": "0x7fffc69b3a80-IntLiteralConstant",
+    "id": "0x7fffbd703950-IntLiteralConstant",
     "CharBlock": "2"
   },
   {
-    "id": "0x7fffc69b2d20-Statement",
-    "statement": "0x7fffc69b2d30-EndProgramStmt",
+    "id": "0x7fffbd7062f8-ExecutionPart",
+    "ExecutionPartConstruct": [
+      "0x7fffbd7048f0-ExecutionPartConstruct",
+      "0x7fffbd705500-ExecutionPartConstruct",
+      "0x7fffbd705ea0-ExecutionPartConstruct"]
+  },
+  {
+    "id": "0x7fffbd7062f8-ExecutionPartConstruct"
+  },
+  {
+    "id": "0x7fffbd7048f0-ExecutionPartConstruct",
+    "value": "0x7fffbd7048f0-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffbd7048f0-ExecutableConstruct",
+    "value": "0x7fffbd6c4490-DoConstruct"
+  },
+  {
+    "id": "0x7fffbd6c4490-DoConstruct",
+    "Statement<NonLabelDoStmt>": "0x7fffbd6c44e8-Statement",
+    "ExecutionPartConstruct": [
+      "0x7fffbd703870-ExecutionPartConstruct",
+      "0x7fffbd705780-ExecutionPartConstruct"],
+    "Statement<EndDoStmt>": "0x7fffbd6c4490-Statement"
+  },
+  {
+    "id": "0x7fffbd6c44e8-Statement",
+    "statement": "0x7fffbd6c44f8-NonLabelDoStmt",
     "label": "null",
-    "source": "end program array_demonstration"
+    "source": "do i = 1, 5, a"
   },
   {
-    "id": "0x7fffc69b2d30-EndProgramStmt",
-    "Name": "0x7fffc69b2d30-Name"
+    "id": "0x7fffbd6c44f8-NonLabelDoStmt",
+    "LoopControl": "0x7fffbd6c44f8-LoopControl"
   },
   {
-    "id": "0x7fffc69b2d30-Name",
-    "source": "array_demonstration"
+    "id": "0x7fffbd6c44f8-LoopControl",
+    "value": "0x7fffbd6c44f8-LoopBounds",
+    "kind": "Range"
+  },
+  {
+    "id": "0x7fffbd6c44f8-LoopBounds",
+    "var": "0x7fffbd6c44f8-Name",
+    "lower": "0x7fffbd705190-Expr",
+    "upper": "0x7fffbd705270-Expr",
+    "step": "0x7fffbd7053b0-Expr"
+  },
+  {
+    "id": "0x7fffbd6c44f8-Name",
+    "source": "i"
+  },
+  {
+    "id": "0x7fffbd705190-Expr",
+    "value": "0x7fffbd7051b0-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd7051b0-LiteralConstant",
+    "value": "0x7fffbd7051b0-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd7051b0-IntLiteralConstant",
+    "CharBlock": "1"
+  },
+  {
+    "id": "0x7fffbd705270-Expr",
+    "value": "0x7fffbd705290-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705290-LiteralConstant",
+    "value": "0x7fffbd705290-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705290-IntLiteralConstant",
+    "CharBlock": "5"
+  },
+  {
+    "id": "0x7fffbd7053b0-Expr",
+    "value": "0x7fffbd705350-Designator"
+  },
+  {
+    "id": "0x7fffbd705350-Designator",
+    "value": "0x7fffbd705360-DataRef"
+  },
+  {
+    "id": "0x7fffbd705360-DataRef",
+    "value": "0x7fffbd705360-Name"
+  },
+  {
+    "id": "0x7fffbd705360-Name",
+    "source": "a"
+  },
+  {
+    "id": "0x7fffbd6c44d0-ExecutionPartConstruct"
+  },
+  {
+    "id": "0x7fffbd703870-ExecutionPartConstruct",
+    "value": "0x7fffbd703870-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffbd703870-ExecutableConstruct",
+    "value<ActionStmt>": "0x7fffbd703870-Statement"
+  },
+  {
+    "id": "0x7fffbd703870-Statement",
+    "statement": "0x7fffbd703880-ActionStmt",
+    "label": "null",
+    "source": "dummy = 3"
+  },
+  {
+    "id": "0x7fffbd703880-ActionStmt",
+    "value": "0x7fffbd705550-AssignmentStmt"
+  },
+  {
+    "id": "0x7fffbd705550-AssignmentStmt",
+    "Variable": "0x7fffbd705630-Variable",
+    "Expr": "0x7fffbd705560-Expr"
+  },
+  {
+    "id": "0x7fffbd705630-Variable",
+    "value": "0x7fffbd6dfce0-Designator"
+  },
+  {
+    "id": "0x7fffbd6dfce0-Designator",
+    "value": "0x7fffbd6dfcf0-DataRef"
+  },
+  {
+    "id": "0x7fffbd6dfcf0-DataRef",
+    "value": "0x7fffbd6dfcf0-Name"
+  },
+  {
+    "id": "0x7fffbd6dfcf0-Name",
+    "source": "dummy"
+  },
+  {
+    "id": "0x7fffbd705560-Expr",
+    "value": "0x7fffbd705580-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705580-LiteralConstant",
+    "value": "0x7fffbd705580-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705580-IntLiteralConstant",
+    "CharBlock": "3"
+  },
+  {
+    "id": "0x7fffbd705780-ExecutionPartConstruct",
+    "value": "0x7fffbd705780-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffbd705780-ExecutableConstruct",
+    "value<ActionStmt>": "0x7fffbd705780-Statement"
+  },
+  {
+    "id": "0x7fffbd705780-Statement",
+    "statement": "0x7fffbd705790-ActionStmt",
+    "label": "null",
+    "source": "dummy = 4"
+  },
+  {
+    "id": "0x7fffbd705790-ActionStmt",
+    "value": "0x7fffbd705660-AssignmentStmt"
+  },
+  {
+    "id": "0x7fffbd705660-AssignmentStmt",
+    "Variable": "0x7fffbd705740-Variable",
+    "Expr": "0x7fffbd705670-Expr"
+  },
+  {
+    "id": "0x7fffbd705740-Variable",
+    "value": "0x7fffbd6d9230-Designator"
+  },
+  {
+    "id": "0x7fffbd6d9230-Designator",
+    "value": "0x7fffbd6d9240-DataRef"
+  },
+  {
+    "id": "0x7fffbd6d9240-DataRef",
+    "value": "0x7fffbd6d9240-Name"
+  },
+  {
+    "id": "0x7fffbd6d9240-Name",
+    "source": "dummy"
+  },
+  {
+    "id": "0x7fffbd705670-Expr",
+    "value": "0x7fffbd705690-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705690-LiteralConstant",
+    "value": "0x7fffbd705690-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705690-IntLiteralConstant",
+    "CharBlock": "4"
+  },
+  {
+    "id": "0x7fffbd6c4490-Statement",
+    "statement": "0x7fffbd6c44a0-EndDoStmt",
+    "label": "null",
+    "source": "end do"
+  },
+  {
+    "id": "0x7fffbd6c44a0-EndDoStmt"
+  },
+  {
+    "id": "0x7fffbd705500-ExecutionPartConstruct",
+    "value": "0x7fffbd705500-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffbd705500-ExecutableConstruct",
+    "value": "0x7fffbd705d10-DoConstruct"
+  },
+  {
+    "id": "0x7fffbd705d10-DoConstruct",
+    "Statement<NonLabelDoStmt>": "0x7fffbd705d68-Statement",
+    "ExecutionPartConstruct": [
+      "0x7fffbd705cc0-ExecutionPartConstruct"],
+    "Statement<EndDoStmt>": "0x7fffbd705d10-Statement"
+  },
+  {
+    "id": "0x7fffbd705d68-Statement",
+    "statement": "0x7fffbd705d78-NonLabelDoStmt",
+    "label": "null",
+    "source": "do while(2 > 0)"
+  },
+  {
+    "id": "0x7fffbd705d78-NonLabelDoStmt",
+    "LoopControl": "0x7fffbd705d78-LoopControl"
+  },
+  {
+    "id": "0x7fffbd705d78-LoopControl",
+    "value": "0x7fffbd705a00-Expr",
+    "kind": "While"
+  },
+  {
+    "id": "0x7fffbd705a00-Expr",
+    "value": "0x7fffbd705a20-GT"
+  },
+  {
+    "id": "0x7fffbd705a20-GT",
+    "left": "0x7fffbd705920-Expr",
+    "right": "0x7fffbd705840-Expr",
+    "op": "GT"
+  },
+  {
+    "id": "0x7fffbd705920-Expr",
+    "value": "0x7fffbd705940-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705940-LiteralConstant",
+    "value": "0x7fffbd705940-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705940-IntLiteralConstant",
+    "CharBlock": "2"
+  },
+  {
+    "id": "0x7fffbd705840-Expr",
+    "value": "0x7fffbd705860-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705860-LiteralConstant",
+    "value": "0x7fffbd705860-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705860-IntLiteralConstant",
+    "CharBlock": "0"
+  },
+  {
+    "id": "0x7fffbd705d50-ExecutionPartConstruct"
+  },
+  {
+    "id": "0x7fffbd705cc0-ExecutionPartConstruct",
+    "value": "0x7fffbd705cc0-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffbd705cc0-ExecutableConstruct",
+    "value<ActionStmt>": "0x7fffbd705cc0-Statement"
+  },
+  {
+    "id": "0x7fffbd705cc0-Statement",
+    "statement": "0x7fffbd705cd0-ActionStmt",
+    "label": "null",
+    "source": "dummy = 2"
+  },
+  {
+    "id": "0x7fffbd705cd0-ActionStmt",
+    "value": "0x7fffbd705ba0-AssignmentStmt"
+  },
+  {
+    "id": "0x7fffbd705ba0-AssignmentStmt",
+    "Variable": "0x7fffbd705c80-Variable",
+    "Expr": "0x7fffbd705bb0-Expr"
+  },
+  {
+    "id": "0x7fffbd705c80-Variable",
+    "value": "0x7fffbd705490-Designator"
+  },
+  {
+    "id": "0x7fffbd705490-Designator",
+    "value": "0x7fffbd7054a0-DataRef"
+  },
+  {
+    "id": "0x7fffbd7054a0-DataRef",
+    "value": "0x7fffbd7054a0-Name"
+  },
+  {
+    "id": "0x7fffbd7054a0-Name",
+    "source": "dummy"
+  },
+  {
+    "id": "0x7fffbd705bb0-Expr",
+    "value": "0x7fffbd705bd0-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705bd0-LiteralConstant",
+    "value": "0x7fffbd705bd0-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705bd0-IntLiteralConstant",
+    "CharBlock": "2"
+  },
+  {
+    "id": "0x7fffbd705d10-Statement",
+    "statement": "0x7fffbd705d20-EndDoStmt",
+    "label": "null",
+    "source": "end do"
+  },
+  {
+    "id": "0x7fffbd705d20-EndDoStmt"
+  },
+  {
+    "id": "0x7fffbd705ea0-ExecutionPartConstruct",
+    "value": "0x7fffbd705ea0-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffbd705ea0-ExecutableConstruct",
+    "value": "0x7fffbd706060-DoConstruct"
+  },
+  {
+    "id": "0x7fffbd706060-DoConstruct",
+    "Statement<NonLabelDoStmt>": "0x7fffbd7060b8-Statement",
+    "ExecutionPartConstruct": [
+      "0x7fffbd706010-ExecutionPartConstruct"],
+    "Statement<EndDoStmt>": "0x7fffbd706060-Statement"
+  },
+  {
+    "id": "0x7fffbd7060b8-Statement",
+    "statement": "0x7fffbd7060c8-NonLabelDoStmt",
+    "label": "null",
+    "source": "name: do"
+  },
+  {
+    "id": "0x7fffbd7060c8-NonLabelDoStmt",
+    "Name": "0x7fffbd706148-Name"
+  },
+  {
+    "id": "0x7fffbd706148-Name",
+    "source": "name"
+  },
+  {
+    "id": "0x7fffbd7060a0-ExecutionPartConstruct"
+  },
+  {
+    "id": "0x7fffbd706010-ExecutionPartConstruct",
+    "value": "0x7fffbd706010-ExecutableConstruct"
+  },
+  {
+    "id": "0x7fffbd706010-ExecutableConstruct",
+    "value<ActionStmt>": "0x7fffbd706010-Statement"
+  },
+  {
+    "id": "0x7fffbd706010-Statement",
+    "statement": "0x7fffbd706020-ActionStmt",
+    "label": "null",
+    "source": "dummy = 4"
+  },
+  {
+    "id": "0x7fffbd706020-ActionStmt",
+    "value": "0x7fffbd705ef0-AssignmentStmt"
+  },
+  {
+    "id": "0x7fffbd705ef0-AssignmentStmt",
+    "Variable": "0x7fffbd705fd0-Variable",
+    "Expr": "0x7fffbd705f00-Expr"
+  },
+  {
+    "id": "0x7fffbd705fd0-Variable",
+    "value": "0x7fffbd705e30-Designator"
+  },
+  {
+    "id": "0x7fffbd705e30-Designator",
+    "value": "0x7fffbd705e40-DataRef"
+  },
+  {
+    "id": "0x7fffbd705e40-DataRef",
+    "value": "0x7fffbd705e40-Name"
+  },
+  {
+    "id": "0x7fffbd705e40-Name",
+    "source": "dummy"
+  },
+  {
+    "id": "0x7fffbd705f00-Expr",
+    "value": "0x7fffbd705f20-LiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705f20-LiteralConstant",
+    "value": "0x7fffbd705f20-IntLiteralConstant"
+  },
+  {
+    "id": "0x7fffbd705f20-IntLiteralConstant",
+    "CharBlock": "4"
+  },
+  {
+    "id": "0x7fffbd706060-Statement",
+    "statement": "0x7fffbd706070-EndDoStmt",
+    "label": "null",
+    "source": "end do name"
+  },
+  {
+    "id": "0x7fffbd706070-EndDoStmt",
+    "Name": "0x7fffbd706070-Name"
+  },
+  {
+    "id": "0x7fffbd706070-Name",
+    "source": "name"
+  },
+  {
+    "id": "0x7fffbd706270-Statement",
+    "statement": "0x7fffbd706280-EndProgramStmt",
+    "label": "null",
+    "source": "end program simple_loop"
+  },
+  {
+    "id": "0x7fffbd706280-EndProgramStmt",
+    "Name": "0x7fffbd706280-Name"
+  },
+  {
+    "id": "0x7fffbd706280-Name",
+    "source": "simple_loop"
   }],
   "enums": {
     "Fortran::common::CUDADataAttr": ["Constant", "Device", "Managed", "Pinned", "Shared", "Texture", "Unified"],

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/FlangName.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/FlangName.java
@@ -85,6 +85,7 @@ public enum FlangName implements StringProvider {
     ARRAY_CONSTRUCTOR,
     AC_SPEC,
     AC_VALUE,
+    ARRAY_ELEMENT,
 
     /// TYPEs
     DECLARATION_TYPE_SPEC,

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/FlangToClass.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/FlangToClass.java
@@ -92,6 +92,7 @@ public class FlangToClass {
         NAME_TO_CLASS.put(FlangName.GE, BinaryOperator.class);
         NAME_TO_CLASS.put(FlangName.ARRAY_CONSTRUCTOR, ArrayConstructor.class);
         NAME_TO_CLASS.put(FlangName.AC_SPEC, AcSpecification.class);
+        NAME_TO_CLASS.put(FlangName.ARRAY_ELEMENT, ArraySubscriptExpr.class);
 
         /// TYPEs
         NAME_TO_CLASS.put(FlangName.INTEGER_TYPE_SPEC, IntegerType.class);

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/FlangToClass.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/FlangToClass.java
@@ -71,7 +71,8 @@ public class FlangToClass {
         NAME_TO_CLASS.put(FlangName.END_SELECT_STMT, EndSelectStmt.class);
 
         /// Variables
-        NAME_TO_CLASS.put(FlangName.DATA_REF, DataRef.class);
+        //NAME_TO_CLASS.put(FlangName.DATA_REF, DataRef.class);
+        NAME_TO_CLASS.put(FlangName.NAME, DataRef.class);
 
         /// EXPRs
         NAME_TO_CLASS.put(FlangName.CHAR_LITERAL_CONSTANT, StringLiteral.class);

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/ExprProcessors.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/ExprProcessors.java
@@ -1,12 +1,6 @@
 package pt.up.fe.specs.fortran.parser.processors;
 
-import pt.up.fe.specs.fortran.ast.nodes.expr.BinaryOperator;
-import pt.up.fe.specs.fortran.ast.nodes.expr.IntLiteral;
-import pt.up.fe.specs.fortran.ast.nodes.expr.LogicalLiteral;
-import pt.up.fe.specs.fortran.ast.nodes.expr.ParenExpr;
-import pt.up.fe.specs.fortran.ast.nodes.expr.StringLiteral;
-import pt.up.fe.specs.fortran.ast.nodes.expr.ArrayConstructor;
-import pt.up.fe.specs.fortran.ast.nodes.expr.AcSpecification;
+import pt.up.fe.specs.fortran.ast.nodes.expr.*;
 import pt.up.fe.specs.fortran.ast.nodes.expr.enums.BinaryOperatorKind;
 import pt.up.fe.specs.fortran.parser.FlangName;
 import pt.up.fe.specs.fortran.parser.FortranJsonResult;
@@ -57,4 +51,8 @@ public class ExprProcessors extends ANodeProcessor {
         acSpecification.addChildren(acValueList);
     }
 
+    public void arraySubscriptExpr(ArraySubscriptExpr arraySubscriptExpr) {
+        arraySubscriptExpr.addChild(getChild(arraySubscriptExpr, "base"));
+        arraySubscriptExpr.addChildren(getChildren(arraySubscriptExpr, "subscripts"));
+    }
 }

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/Nodes.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/Nodes.java
@@ -95,6 +95,7 @@ public class Nodes {
         processors.put(BinaryOperator.class, e::binaryOperator);
         processors.put(ArrayConstructor.class, e::arrayConstructor);
         processors.put(AcSpecification.class, e::acSpecification);
+        processors.put(ArraySubscriptExpr.class, e::arraySubscriptExpr);
 
         var t = new TypeProcessors(data);
         processors.put(IntegerType.class, t::integerType);

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/VariableProcessor.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/VariableProcessor.java
@@ -9,10 +9,11 @@ public class VariableProcessor extends ANodeProcessor {
     }
 
     public void dataRefProcessor(DataRef dataRef) {
-        var nameId = attributes(dataRef).getString("value");
-        var name = attributes().get(nameId).getOptionalString("source");
 
-        name.ifPresent(str -> dataRef.set(DataRef.NAME, str));
+        //var nameId = attributes(dataRef).getString("value");
+        //var name = attributes().get(nameId).getOptionalString("source");
+        String name = attributes(dataRef).getString("source");
+
         dataRef.set(DataRef.NAME, name);
     }
 }

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/VariableProcessor.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/VariableProcessor.java
@@ -10,8 +10,6 @@ public class VariableProcessor extends ANodeProcessor {
 
     public void dataRefProcessor(DataRef dataRef) {
 
-        //var nameId = attributes(dataRef).getString("value");
-        //var name = attributes().get(nameId).getOptionalString("source");
         String name = attributes(dataRef).getString("source");
 
         dataRef.set(DataRef.NAME, name);

--- a/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/VariableProcessor.java
+++ b/FortranParser/src/pt/up/fe/specs/fortran/parser/processors/VariableProcessor.java
@@ -10,8 +10,9 @@ public class VariableProcessor extends ANodeProcessor {
 
     public void dataRefProcessor(DataRef dataRef) {
         var nameId = attributes(dataRef).getString("value");
-        var name = attributes().get(nameId).getString("source");
+        var name = attributes().get(nameId).getOptionalString("source");
 
+        name.ifPresent(str -> dataRef.set(DataRef.NAME, str));
         dataRef.set(DataRef.NAME, name);
     }
 }

--- a/FortranParser/test/pt/up/fe/specs/fortran/parser/FortranParserTest.java
+++ b/FortranParser/test/pt/up/fe/specs/fortran/parser/FortranParserTest.java
@@ -248,4 +248,16 @@ public class FortranParserTest {
     void testNamedSelectCase() {
         testJson("conditionalstmt/named_select_case.json");
     }
+
+    @Test
+    void testArrayElementAccess() {
+        testJson("arrays/element_access.json");
+    }
+
+    @Test
+    void testArrayElementAccessNative() {
+        if (SpecsPlatforms.isLinux()) {
+            testNative("arrays/element_access.f90");
+        }
+    }
 }


### PR DESCRIPTION
Adds support for simple array element accesses. Only simple accesses (arrayname(expr, expr, ...)) have been tested.
Changes the point of the AST at which DataRefs are processed to allow for different processors depending on the contents of the DataRef node.