### PR TITLE
Add joinpoint methods to check descendants and ancestors

### DIFF
--- a/FortranWeaver/resources/fortran/weaverspecs/artifacts.xml
+++ b/FortranWeaver/resources/fortran/weaverspecs/artifacts.xml
@@ -20,6 +20,14 @@
         <!-- TODO: TEMP FIX WHILE GENERATOR DOES NOT ADD THIS BASE ATTRIBUTE AUTOMATICALLY -->
         <attribute name="scopeNodes" type="joinpoint[]"
                    tooltip="the nodes of the scope of the current join point. If this node has a body (e.g., loop, function) corresponds to the children of the body. Otherwise, returns an empty array"/>
+        <attribute name="getAncestor" type="joinpoint"
+                   tooltip="Looks for an ancestor joinpoint name, walking back on the AST">
+            <parameter name="type" type="String"/>
+        </attribute>
+        <attribute name="contains" type="Boolean"
+                   tooltip="true if the given node is a descendant of this node">
+            <parameter name="jp" type="joinpoint"/>
+        </attribute>
     </global>
 
     <!-- PROGRAM -->

--- a/FortranWeaver/src/pt/up/fe/specs/fortran/weaver/FortranWeaver.json
+++ b/FortranWeaver/src/pt/up/fe/specs/fortran/weaver/FortranWeaver.json
@@ -27,11 +27,39 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "true if the given node is a descendant of this node",
+						"children": [
+									{
+										"type": "Boolean",
+										"name": "contains"
+									},
+									{
+										"type": "joinpoint",
+										"name": "jp",
+										"defaultValue": ""
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns an array with the descendants of the node",
 						"children": [
 									{
 										"type": "joinpoint[]",
 										"name": "descendants"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "Looks for an ancestor joinpoint name, walking back on the AST",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "getAncestor"
+									},
+									{
+										"type": "String",
+										"name": "type",
+										"defaultValue": ""
 									}]
 					},
 					{
@@ -121,11 +149,39 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "true if the given node is a descendant of this node",
+						"children": [
+									{
+										"type": "Boolean",
+										"name": "contains"
+									},
+									{
+										"type": "joinpoint",
+										"name": "jp",
+										"defaultValue": ""
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns an array with the descendants of the node",
 						"children": [
 									{
 										"type": "joinpoint[]",
 										"name": "descendants"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "Looks for an ancestor joinpoint name, walking back on the AST",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "getAncestor"
+									},
+									{
+										"type": "String",
+										"name": "type",
+										"defaultValue": ""
 									}]
 					},
 					{
@@ -196,11 +252,39 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "true if the given node is a descendant of this node",
+						"children": [
+									{
+										"type": "Boolean",
+										"name": "contains"
+									},
+									{
+										"type": "joinpoint",
+										"name": "jp",
+										"defaultValue": ""
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns an array with the descendants of the node",
 						"children": [
 									{
 										"type": "joinpoint[]",
 										"name": "descendants"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "Looks for an ancestor joinpoint name, walking back on the AST",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "getAncestor"
+									},
+									{
+										"type": "String",
+										"name": "type",
+										"defaultValue": ""
 									}]
 					},
 					{
@@ -287,11 +371,39 @@
 					},
 					{
 						"type": "attribute",
+						"tooltip": "true if the given node is a descendant of this node",
+						"children": [
+									{
+										"type": "Boolean",
+										"name": "contains"
+									},
+									{
+										"type": "joinpoint",
+										"name": "jp",
+										"defaultValue": ""
+									}]
+					},
+					{
+						"type": "attribute",
 						"tooltip": "Returns an array with the descendants of the node",
 						"children": [
 									{
 										"type": "joinpoint[]",
 										"name": "descendants"
+									}]
+					},
+					{
+						"type": "attribute",
+						"tooltip": "Looks for an ancestor joinpoint name, walking back on the AST",
+						"children": [
+									{
+										"type": "joinpoint",
+										"name": "getAncestor"
+									},
+									{
+										"type": "String",
+										"name": "type",
+										"defaultValue": ""
 									}]
 					},
 					{

--- a/FortranWeaver/src/pt/up/fe/specs/fortran/weaver/abstracts/AFortranWeaverJoinPoint.java
+++ b/FortranWeaver/src/pt/up/fe/specs/fortran/weaver/abstracts/AFortranWeaverJoinPoint.java
@@ -6,8 +6,10 @@ import pt.up.fe.specs.fortran.ast.utils.Position;
 import pt.up.fe.specs.fortran.weaver.FortranJoinpoints;
 import pt.up.fe.specs.fortran.weaver.abstracts.joinpoints.AJoinPoint;
 import pt.up.fe.specs.fortran.weaver.abstracts.joinpoints.AProgram;
+import pt.up.fe.specs.util.SpecsLogs;
 import pt.up.fe.specs.util.exceptions.NotImplementedException;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -95,5 +97,36 @@ public abstract class AFortranWeaverJoinPoint extends AJoinPoint {
     @Override
     public int hashCode() {
         return getNode().hashCode();
+    }
+
+    @Override
+    public AJoinPoint getAncestorImpl(String type) {
+        Objects.requireNonNull(type, () -> "Missing type of ancestor in attribute 'ancestor'");
+
+        if (type.equals("program")) {
+            SpecsLogs.warn("Consider using attribute .root, instead of .ancestor('program')");
+        }
+
+        FortranNode currentNode = getNode();
+        while (currentNode.hasParent()) {
+            // Create join point for testing type
+            AFortranWeaverJoinPoint parentJp = FortranJoinpoints.create(currentNode.getParent());
+
+            if (parentJp.instanceOf(type)) {
+                return parentJp;
+            }
+
+            currentNode = parentJp.getNode();
+        }
+
+        return null;
+    }
+
+    @Override
+    public Boolean containsImpl(AJoinPoint jp) {
+        FortranNode clavaNode = jp.getNode();
+
+        return getNode().getDescendantsStream()
+                .anyMatch(child -> child == clavaNode);
     }
 }


### PR DESCRIPTION
Adds two global joinpoint methods, one to find an ancestor of a given type, and one to check if a joinpoint is a descendant of another one.